### PR TITLE
Update debug-common_problems.de.md

### DIFF
--- a/docs/troubleshooting/debug-common_problems.de.md
+++ b/docs/troubleshooting/debug-common_problems.de.md
@@ -85,7 +85,7 @@ key.pem
 Wenn `dhparams.pem` fehlt, können Sie es mit Bash
 
 ```bash
-openssl dhparam -out data/assets/ssl/dhparams.pem 4096
+sudo openssl dhparam -out data/assets/ssl/dhparams.pem 4096
 ```
 
 ## Rspamd meldet: cannot open hyperscan cache file /var/lib/rspamd/{...}.hs: compiled for a different platform


### PR DESCRIPTION
Mailcow's Dovecot container will not see dhparam.pem unless it is generated as root, and adding sudo will make it so any users running the command won't be confused as to why dovecot is still not running